### PR TITLE
Minor fixes to README.adoc

### DIFF
--- a/asciidoc-to-html-example/README.adoc
+++ b/asciidoc-to-html-example/README.adoc
@@ -13,7 +13,7 @@ Open the file _target/generated-docs/example-manual.html_ in your browser to see
 
 == Differences from the original example
 
-. Construction is executed on `build` phase, not in `process-resources` phase.
+. `process-asciidoc` is executed on `build` phase, not in `process-resources` phase.
 . The kindlegen execution was commented because it is not relevant for this example.
 . The example project packaging is `pom`, instead of `jar`, to avoid generating an empty jar.
 . Please, note that if you invoke the `package` goal you don't get nothing.

--- a/asciidoctor-epub-example/README.adoc
+++ b/asciidoctor-epub-example/README.adoc
@@ -19,7 +19,7 @@ If you want to generate a kindle document, you can enable a second execution blo
 
 == Differences from the original example
 
-. Construction is executed on `build` phase, not in `process-resources` phase.
+. `process-asciidoc` is executed on `build` phase, not in `process-resources` phase.
 . The kindlegen execution was commented because it is not relevant for this example.
 . The example project packaging is `pom`, instead of `jar`, to avoid generating an empty jar.
 . Please, note that if you invoke the `package` goal you don't get nothing.


### PR DESCRIPTION
Replace the **Construction** word with **process-asciidoc**.